### PR TITLE
fixed bug with publishing - cdn url was wrong

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ embed_images <- function(html_in){
 #' 
 #' @noRd
 enable_cdn <- function(html){
-  cdn  = 'http://slidify.googlecode.com/git/inst/libraries/'
+  cdn  = 'http://slidifylibraries.googlecode.com/git/inst/libraries/'
   html = gsub("libraries/", cdn, html, fixed = TRUE)
 }
 


### PR DESCRIPTION
Updated enable_cdn to use slidifylibraries.googlecode.com rather than slidify.googlecode.com, fixing bug with publishing slides 
