### PR TITLE
Added HTTPS to publish_github

### DIFF
--- a/R/publish.R
+++ b/R/publish.R
@@ -80,8 +80,9 @@ publish_github <- function(repo, username = getOption('github.user'), ssh = TRUE
   # Tested on Win 7, Pro, R 3.0.2, RStudio 0.98.501
   # Tested on Ubuntu 12.04 LTS, R 3.02, RStudio Server 0.98.501
   system('git push origin gh-pages')
-  #changes back to original remote so as not to store password inside of .git
-  system(sprintf('git remote set-url origin %s', remote))
+  #changes back to remote withour passwords
+  system(sprintf('git remote set-url origin https://github.com/%s/%s.git', 
+                 username,repo))
   
   link = sprintf('http://%s.github.com/%s', username, repo)
   message('You can now view your slide deck at ', link)


### PR DESCRIPTION
Ramnath,  

So here it is.  Documentation updated as well as publish_github for https.  As I said in the comments on my originl commit, I am not sure what sort of security problems this raises.  Any solutions to that, I'd be hacking as I am not knowledgeable about that stuff. 

Currently there isn't any checking for username and password, although that'd be an easy addition.  I did specify this in the comments, I can probably find some time to add the checking in if you want it.

Cheers,
Jeff
