### PR TITLE
Windows wants double quotes; should work for Linux / Unix as well.

### DIFF
--- a/R/author.R
+++ b/R/author.R
@@ -1,13 +1,13 @@
 #' Author a slide deck
-#' 
+#'
 #' This function creates a slide directory, initializes it as a git repo and
 #' opens index.Rmd for users to edit.
 #' @param deckdir path to new slide directory
 #' @param use_git whether to initialize directory as git repo
 #' @param open_rmd whether to open the rmd file created
-#' @param scaffold path to directory containing scaffold for deck 
+#' @param scaffold path to directory containing scaffold for deck
 #' @export
-author <- function(deckdir, use_git = TRUE, open_rmd = TRUE, 
+author <- function(deckdir, use_git = TRUE, open_rmd = TRUE,
     scaffold = system.file('skeleton', package = 'slidify')){
   message('Creating slide directory at ', deckdir, '...')
   #   if (file.exists(deckdir)){
@@ -27,13 +27,13 @@ author <- function(deckdir, use_git = TRUE, open_rmd = TRUE,
 }
 
 #' Initialize a git repository, create and switch to gh-pages branch.
-#' 
+#'
 #' @keywords internal
 #' @noRd
 init_repo <- function(){
   message('Initializing Git Repo')
   system("git init")
-  system("git commit --allow-empty -m 'Initial Commit'")
+  system("git commit --allow-empty -m \"Initial Commit\"")
   message("Checking out gh-pages branch...")
   system('git checkout -b gh-pages')
   message('Adding .nojekyll to repo')


### PR DESCRIPTION
Now tested on Windows, MacOS, Linux.  ;-)