### PR TITLE
change github publish url link

### DIFF
--- a/R/publish.R
+++ b/R/publish.R
@@ -56,7 +56,7 @@ publish_github <- function(repo, username = getOption('github.user')){
   system('git add .')
   system('git commit -a -m "publishing deck"')
   system(sprintf('git push git@github.com:%s/%s gh-pages', username, repo))
-  link = sprintf('http://%s.github.com/%s', username, repo)
+  link = sprintf('http://%s.github.io/%s', username, repo)
   message('You can now view your slide deck at ', link)
   browseURL(link)
 }


### PR DESCRIPTION
It seems that the publish_github url setting : " _username_.github.com/_repo_ " is no longer working. The url link to the published webpage should be changed to " _username_.github.io/_repo_ ".
